### PR TITLE
Resize swapfile

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,5 @@
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     swap_file: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ log/
 junit/
 .yar*
 doc/
+.bundle/
 
 # Puppet
 coverage/

--- a/lib/facter/swap_file_size.rb
+++ b/lib/facter/swap_file_size.rb
@@ -1,0 +1,19 @@
+Facter.add('swap_file_size') do
+  confine :kernel => :linux
+  setcode do
+    swap_file_size = 0
+    if File.exists?('/proc/swaps')
+      File.open('/proc/swaps', 'r').each_line do |line|
+        # Find first swapfile entry
+        swap_file = $1 if line.match(/^(\/.[\/\-_.A-Za-z0-9]*)/)
+        next if swap_file.nil?
+        if File.exist?(swap_file)
+          size = File.stat(swap_file).size
+          swap_file_size = (size / 1073741824.0).round(2) if size
+        end
+        break if ! swap_file.nil?
+      end
+    end
+    Facter::Memory.scale_number(swap_file_size.to_f, "GB")
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 describe 'swap_file' do
   let(:facts) do
     {
-      :memorysize => '1.00 GB',
+      :memorysize     => '1.00 GB',
+      :swap_file_size => '2.00 GB',
     }
   end
 
@@ -28,8 +29,8 @@ describe 'swap_file' do
 
     it { should compile.with_all_deps }
     it { should contain_class('swap_file') }
-    # subclass swap_file::files adds 4 resources for each given file
-    it { should have_resource_count(10) }
+    # subclass swap_file::files adds 11 resources for each given file
+    it { should have_resource_count(17) }
 
     it do
       should contain_swap_file__files('swap').with({
@@ -50,6 +51,7 @@ describe 'swap_file' do
         :fqdn              => 'files',
         :parameter_tests   => 'files_hiera_merge',
         :memorysize        => '1.00 GB',
+        :swap_file_size    => '2.00 GB',
       }
     end
 
@@ -57,7 +59,7 @@ describe 'swap_file' do
       let(:params) { { :files_hiera_merge => false } }
       it { should compile.with_all_deps }
       it { should contain_class('swap_file') }
-      it { should have_resource_count(5) }
+      it { should have_resource_count(9) }
 
       it do
         should contain_swap_file__files('resource_name').with({
@@ -71,7 +73,7 @@ describe 'swap_file' do
       let(:params) { { :files_hiera_merge => true } }
       it { should compile.with_all_deps }
       it { should contain_class('swap_file') }
-      it { should have_resource_count(15) }
+      it { should have_resource_count(25) }
 
       it do
         should contain_swap_file__files('resource_name').with({
@@ -103,8 +105,9 @@ describe 'swap_file' do
     # set needed custom facts and variables
     let(:facts) do
       {
-        :osfamily => 'RedHat',
-        :memorysize => '1.00 GB',
+        :osfamily       => 'RedHat',
+        :memorysize     => '1.00 GB',
+        :swap_file_size => '2.00 GB',
       }
     end
     let(:validation_params) do


### PR DESCRIPTION
This adds an automatic swap file resize functionality to your swap_file puppet module.

The way it works is I've created a `$::swap_file_size` facter fact that parses `/proc/swaps` for the first swap file entry and then does a `File.stat` on the file to determine the byte size of the swap file. The fact then converts the byte size to GiB and formats the fact output as a string to match the output of the built-in `$::memorysize` fact.

The Puppet code then compares the `$::swap_file_size` fact with the `$swapfilesize` string parameter. If these two string values match then no resize operation will take place, if they do not match then the `$::swapfree` and `$::swapsize` facts are compared to ensure that no swap activity is occurring before continuing with the resize.

The swap file resize is accomplished by a series of resource ordered exec's: `/sbin/swapoff` followed by an `rm -f` exec to delete the unused swap file, and then run the `Create swap file ${swapfile}` exec using the method specified by the `$cmd` parameter as usual)

The rspec tests have been updated to ensure the resource counters are correct.

I have tested this code on CentOS 7 only but should work on all Linux flavors since `/proc/swaps` output is identical across distributions.