### PR TITLE
Update stdlib versions

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,7 @@
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    stdlib:
+      repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+      ref: 4.2.0
   symlinks:
     swap_file: "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,16 @@ group :development do
 end
 
 group :system_tests do
-  gem 'beaker'
-  gem 'beaker-rspec'
+  gem "beaker",
+    :git => 'https://github.com/puppetlabs/beaker',
+    :ref => '0a7b948aeef8a422e7a86f34012f00166f1dda81',
+    :require => false
+  gem "beaker-rspec",
+    :git => 'https://github.com/puppetlabs/beaker-rspec.git',
+    :ref => 'a617f7bbc3e6ebb6ce49df32749d4ce93cef737d',
+    :require => false
+  gem 'signet', git: "https://github.com/google/signet.git"
+  gem 'serverspec'
+  gem 'specinfra'
 end
 

--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.2.0"
+      "version_requirement": ">= 4.2.0"
     }
   ]
 }

--- a/spec/acceptance/swap_file_class_spec.rb
+++ b/spec/acceptance/swap_file_class_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper_acceptance'
+
+describe 'swap_file class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+
+  context 'swap_file' do
+    context 'ensure => present' do
+      it 'should work with no errors' do
+        pp = <<-EOS
+        class { 'swap_file':
+          files => {
+            'swapfile' => {
+              ensure => 'present',
+            },
+            'use fallocate' => {
+              swapfile => '/tmp/swapfile.fallocate',
+              cmd      => 'fallocate',
+            },
+            'remove swap file' => {
+              ensure   => 'absent',
+              swapfile => '/tmp/swapfile.old',
+            },
+          },
+        }
+        EOS
+
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes  => true)
+      end
+      it 'should contain the default swapfile' do
+        shell('/sbin/swapon -s | grep /mnt/swap.1', :acceptable_exit_codes => [0])
+      end
+      it 'should contain the default fstab setting' do
+        shell('cat /etc/fstab | grep /mnt/swap.1', :acceptable_exit_codes => [0])
+        shell('cat /etc/fstab | grep defaults', :acceptable_exit_codes => [0])
+      end
+      it 'should contain the default swapfile' do
+        shell('/sbin/swapon -s | grep /tmp/swapfile.fallocate', :acceptable_exit_codes => [0])
+      end
+      it 'should contain the default fstab setting' do
+        shell('cat /etc/fstab | grep /tmp/swapfile.fallocate', :acceptable_exit_codes => [0])
+      end
+    end
+  end
+end

--- a/spec/acceptance/swap_file_files_fallocate_command.rb
+++ b/spec/acceptance/swap_file_files_fallocate_command.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'swap_file class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+describe 'swap_file::files defined type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
 
   context 'fallocate command', :unless => ['FreeBSD'].include?(fact('osfamily')) do
     it 'should work with no errors' do

--- a/spec/acceptance/swap_file_files_multiple_spec.rb
+++ b/spec/acceptance/swap_file_files_multiple_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'swap_file class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+describe 'swap_file::files defined type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
 
   context 'multiple swap_file::files', :unless => ['FreeBSD'].include?(fact('osfamily')) do
     it 'should work with no errors' do

--- a/spec/acceptance/swap_file_files_parameters_spec.rb
+++ b/spec/acceptance/swap_file_files_parameters_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'swap_file class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+describe 'swap_file::files defined type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
 
   context 'swap_file' do
     context 'custom parameters' do

--- a/spec/acceptance/swap_file_files_spec.rb
+++ b/spec/acceptance/swap_file_files_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'swap_file class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+describe 'swap_file::files defined type', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
 
   context 'swap_file' do
     context 'ensure => present' do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -25,7 +25,7 @@ RSpec.configure do |c|
     # Install module and dependencies
     puppet_module_install(:source => proj_root, :module_name => 'swap_file')
     hosts.each do |host|
-      shell('puppet module install puppetlabs-stdlib --version 3.2.0', { :acceptable_exit_codes => [0,1] })
+      shell('puppet module install puppetlabs-stdlib --version 4.2.0', { :acceptable_exit_codes => [0,1] })
     end
   end
 end


### PR DESCRIPTION
Updates stdlib dependency …
* `is_bool` was added in 4.2.0
* `swap_file` uses `is_bool` and doesn't work with the version of `stdlib` we're using