### PR TITLE
New feature: resizing existing swapfiles

### DIFF
--- a/lib/puppet/parser/functions/difference_within_margin.rb
+++ b/lib/puppet/parser/functions/difference_within_margin.rb
@@ -1,0 +1,62 @@
+# When given an array of two numbers and a margin, returns true
+# if the difference is less than the margin. Basically statistical
+# range with a margin.
+#
+# @example Difference between 150 and 100 is 50, margin is 60. So true
+#   $within_margin = difference_within_margin([100,150],60)
+#
+# @example Difference between 150 and 100 is 50, margin is 40. So false
+#   $within_margin = difference_within_margin([100,150],40)
+#
+# @return [Boolean] whether the difference between two numbers is within in a margin
+#
+# @param num_a [Array] array of two numbers to compare
+# @param num_b [Float] the margin to compare the two numbers
+module Puppet::Parser::Functions
+  newfunction(:difference_within_margin, :type => :rvalue, :doc => <<-EOS
+Get's the difference between two numbers, with a third argument as a margin
+
+*Example:*
+
+    compare_with_margin(100,150,60)
+
+Would result in:
+
+    true
+
+    compare_with_margin(100,150,40)
+
+Would result in:
+
+    false
+
+    EOS
+  ) do |arguments|
+
+    # Check that more than 2 arguments have been given ...
+    raise(Puppet::ParseError, "compare_with_margin(): Wrong number of arguments " +
+      "given (#{arguments.size} for 2)") unless arguments.size == 2
+
+    # Check that the first parameter is an array
+    unless arguments[0].is_a?(Array)
+      raise(Puppet::ParseError, 'difference_within_margin(): Requires array to work with')
+    end
+
+    # Check that the first parameter is an array
+    if arguments[0].empty?
+      raise(Puppet::ParseError, 'difference_within_margin(): arg[0] array cannot be empty')
+    end
+
+    arguments[0].collect! { |i| i.to_f }
+
+    difference = arguments[0].minmax[1].to_f - arguments[0].minmax[0].to_f
+
+    if difference < arguments[1].to_f
+      return true
+    else
+      return false
+    end
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/manifests/resize.pp
+++ b/manifests/resize.pp
@@ -1,0 +1,51 @@
+# A defined type to resize an existing swapfile
+#
+# @example
+#   ::swap_file::resize { '/mnt/swap.1:
+#     swapfile_path          => '/mnt/swap.1',
+#     margin                 => '500 MB',
+#     expected_swapfile_size => '1 GB,
+#   }
+#
+# @param [String] swapfile_path Path to the swapfile
+# @param [String] expected_swapfile_size Expected size of the swapfile
+# @param [String] actual_swapfile_size Actual size of the swapfile
+# @param [String] margin Margin that is checked before resizing the swapfile
+# @param [Boolean] verbose Adds a notify to explain why the change was made
+#
+# @author - Peter Souter
+#
+define swap_file::resize (
+  $swapfile_path,
+  $expected_swapfile_size,
+  $actual_swapfile_size,
+  $margin                 = '50MB',
+  $verbose                = false,
+)
+{
+  $margin_bytes                  = to_bytes($margin)
+  $existing_swapfile_bytes       = to_bytes("${actual_swapfile_size}kb")
+  $expected_swapfile_size_bytes  = to_bytes($expected_swapfile_size)
+
+  if !($expected_swapfile_size_bytes == $existing_swapfile_bytes) {
+    if !(difference_within_margin([$existing_swapfile_bytes, $expected_swapfile_size_bytes],$margin_bytes)) {
+      if ($verbose) {
+        $alert_message = "Existing : ${existing_swapfile_bytes}B\nExpected: ${expected_swapfile_size_bytes}B\nMargin: ${margin_bytes}B"
+        notify{"Resizing Swapfile Alert ${swapfile_path}":
+          name => $alert_message,
+        }
+      }
+      exec { "Detach swap file ${swapfile_path} for resize":
+        command => "/sbin/swapoff ${swapfile_path}",
+        onlyif  => "/sbin/swapon -s | grep ${swapfile_path}",
+      }
+      ->
+      exec { "Purge ${swapfile_path} for resize":
+        command => "/bin/rm -f ${swapfile_path}",
+        onlyif  => "test -f ${swapfile_path}",
+        path    => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
+      }
+    }
+  }
+
+}

--- a/spec/acceptance/swap_file_resizing_spec.rb
+++ b/spec/acceptance/swap_file_resizing_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper_acceptance'
+
+describe 'swap_file class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+
+  context 'disable stringify_facts' do
+    shell('puppet config set stringify_facts false --section=agent', { :acceptable_exit_codes => [0,1] })
+    shell('puppet config set stringify_facts false', { :acceptable_exit_codes => [0,1] })
+  end
+
+  context 'swap_file' do
+    context 'swapfilesize => 100' do
+      it 'should work with no errors' do
+        pp = <<-EOS
+        swap_file::files { 'default':
+          ensure       => present,
+          swapfilesize => '100MB',
+          resize_existing => true,
+        }
+        EOS
+
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes  => true)
+      end
+      it 'should contain the given swapfile with the correct size (102396/100MB)' do
+        shell('/sbin/swapon -s | grep /mnt/swap.1', :acceptable_exit_codes => [0])
+        shell('/bin/cat /proc/swaps | grep 102396', :acceptable_exit_codes => [0])
+      end
+    end
+    context 'resize swap file' do
+      it 'should work with no errors' do
+        pp = <<-EOS
+        swap_file::files { 'default':
+          ensure          => present,
+          swapfilesize    => '200MB',
+          resize_existing => true,
+        }
+        EOS
+
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+      it 'should contain the given swapfile with the resized size (204796kb/200MB)' do
+        shell('/sbin/swapon -s | grep /mnt/swap.1', :acceptable_exit_codes => [0])
+        shell('/bin/cat /proc/swaps | grep 204796', :acceptable_exit_codes => [0])
+      end
+    end
+  end
+end

--- a/spec/acceptance/swap_file_resizing_stringify_true_spec.rb
+++ b/spec/acceptance/swap_file_resizing_stringify_true_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper_acceptance'
+
+describe 'swap_file class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+
+  context 'disable stringify_facts' do
+    shell('puppet config set stringify_facts true --section=agent', { :acceptable_exit_codes => [0,1] })
+    shell('puppet config set stringify_facts true', { :acceptable_exit_codes => [0,1] })
+  end
+
+  context 'swap_file' do
+    context 'swapfilesize => 100' do
+      it 'should work with no errors' do
+        pp = <<-EOS
+        swap_file::files { 'default':
+          ensure          => present,
+          swapfilesize    => '100MB',
+          resize_existing => true,
+        }
+        EOS
+
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes  => true)
+      end
+      it 'should contain the given swapfile with the correct size (102396/100MB)' do
+        shell('/sbin/swapon -s | grep /mnt/swap.1', :acceptable_exit_codes => [0])
+        shell('/bin/cat /proc/swaps | grep 102396', :acceptable_exit_codes => [0])
+      end
+    end
+    context 'resize swap file' do
+      it 'errors out if stringify_facts is true and resize_existing is true' do
+        pp = <<-EOS
+        swap_file::files { 'default':
+          ensure       => present,
+          swapfilesize => '100MB',
+          resize_existing => true,
+        }
+        EOS
+
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :expect_failures => true) do |r|
+          expect(r.stderr).to match(/stringify_facts was true/)
+        end
+      end
+    end
+  end
+
+end

--- a/spec/defines/files_spec.rb
+++ b/spec/defines/files_spec.rb
@@ -5,11 +5,11 @@ describe 'swap_file::files' do
 
   let(:facts) do
     {
-      :operatingsystem => 'RedHat',
-      :osfamily        => 'RedHat',
-      :operatingsystemrelease => '7',
-      :concat_basedir => '/tmp',
-      :memorysize => '1.00 GB'
+      operatingsystem: 'RedHat',
+      osfamily: 'RedHat',
+      operatingsystemrelease: '7',
+      concat_basedir: '/tmp',
+      memorysize: '1.00 GB'
     }
   end
 
@@ -22,102 +22,95 @@ describe 'swap_file::files' do
       is_expected.to compile.with_all_deps
     end
     it do
-      is_expected.to contain_exec('Create swap file /mnt/swap.1').
-               with({"command"=>"/bin/dd if=/dev/zero of=/mnt/swap.1 bs=1M count=1024",
-                     "creates"=>"/mnt/swap.1"})
+      is_expected.to contain_exec('Create swap file /mnt/swap.1')
+        .with('command' => '/bin/dd if=/dev/zero of=/mnt/swap.1 bs=1M count=1024',
+              'creates' => '/mnt/swap.1')
     end
     it do
-      is_expected.to contain_file('/mnt/swap.1').
-               with({"owner"=>"root",
-                     "group"=>"root",
-                     "mode"=>"0600",
-                     "require"=>"Exec[Create swap file /mnt/swap.1]"})
+      is_expected.to contain_file('/mnt/swap.1')
+        .with('owner' => 'root',
+              'group' => 'root',
+              'mode' => '0600',
+              'require' => 'Exec[Create swap file /mnt/swap.1]')
     end
     it do
-      is_expected.to contain_exec('Attach swap file /mnt/swap.1').
-               with({"command"=>"/sbin/mkswap /mnt/swap.1 && /sbin/swapon /mnt/swap.1",
-                     "require"=>"File[/mnt/swap.1]",
-                     "unless"=>"/sbin/swapon -s | grep /mnt/swap.1"})
+      is_expected.to contain_exec('Attach swap file /mnt/swap.1')
+        .with('command' => '/sbin/mkswap /mnt/swap.1 && /sbin/swapon /mnt/swap.1',
+              'require' => 'File[/mnt/swap.1]',
+              'unless' => '/sbin/swapon -s | grep /mnt/swap.1')
     end
     it do
-      is_expected.to contain_mount('/mnt/swap.1').
-               with({"require"=>"Exec[Attach swap file /mnt/swap.1]"})
+      is_expected.to contain_mount('/mnt/swap.1')
+        .with('require' => 'Exec[Attach swap file /mnt/swap.1]')
     end
   end
 
   context 'custom swapfilesize parameter' do
     let(:params) do
       {
-        #:ensure => "present",
-        #:swapfile => "/mnt/swap.1",
-        :swapfilesize => '4.1 GB',
-        #:add_mount => true,
-        #:options => "defaults",
+        swapfilesize: '4.1 GB'
       }
     end
     it do
       is_expected.to compile.with_all_deps
     end
     it do
-      is_expected.to contain_exec('Create swap file /mnt/swap.1').
-      with({"command"=>"/bin/dd if=/dev/zero of=/mnt/swap.1 bs=1M count=4198",
-       "creates"=>"/mnt/swap.1"})
+      is_expected.to contain_exec('Create swap file /mnt/swap.1')
+        .with('command' => '/bin/dd if=/dev/zero of=/mnt/swap.1 bs=1M count=4198',
+              'creates' => '/mnt/swap.1')
     end
   end
 
   context 'custom swapfilesize parameter with timeout' do
     let(:params) do
       {
-        #:ensure => "present",
-        :swapfile => "/mnt/swap.2",
-        :swapfilesize => '4.1 GB',
-        #:add_mount => true,
-        #:options => "defaults",
-        :timeout => 900,
+        swapfile: '/mnt/swap.2',
+        swapfilesize: '4.1 GB',
+        timeout: 900
       }
     end
     it do
       is_expected.to compile.with_all_deps
     end
     it do
-      is_expected.to contain_exec('Create swap file /mnt/swap.2').
-      with({"command"=>"/bin/dd if=/dev/zero of=/mnt/swap.2 bs=1M count=4198",
-       "timeout"=>900,"creates"=>"/mnt/swap.2"})
+      is_expected.to contain_exec('Create swap file /mnt/swap.2')
+        .with('command' => '/bin/dd if=/dev/zero of=/mnt/swap.2 bs=1M count=4198',
+              'timeout' => 900, 'creates' => '/mnt/swap.2')
     end
   end
 
   context 'custom swapfilesize parameter with timeout' do
     let(:params) do
       {
-        :swapfile => "/mnt/swap.2",
-        :swapfilesize => '4.1 GB',
-        :timeout => 900,
+        swapfile: '/mnt/swap.2',
+        swapfilesize: '4.1 GB',
+        timeout: 900
       }
     end
     it do
       is_expected.to compile.with_all_deps
     end
     it do
-      is_expected.to contain_exec('Create swap file /mnt/swap.2').
-      with({"command"=>"/bin/dd if=/dev/zero of=/mnt/swap.2 bs=1M count=4198",
-       "timeout"=>900,"creates"=>"/mnt/swap.2"})
+      is_expected.to contain_exec('Create swap file /mnt/swap.2')
+        .with('command' => '/bin/dd if=/dev/zero of=/mnt/swap.2 bs=1M count=4198',
+              'timeout' => 900, 'creates' => '/mnt/swap.2')
     end
   end
 
   context 'custom swapfilesize parameter with fallocate' do
     let(:params) do
       {
-        :swapfile => "/mnt/swap.3",
-        :swapfilesize => '4.1 GB',
-        :cmd => 'fallocate',
+        swapfile: '/mnt/swap.3',
+        swapfilesize: '4.1 GB',
+        cmd: 'fallocate'
       }
       it do
         is_expected.to compile.with_all_deps
       end
-      is_expected.to contain_exec('Create swap file /mnt/swap.3').
-        with(
-          {"command"=>"/usr/bin/fallocate -l 4198M /mnt/swap.3",
-            "creates"=>"/mnt/swap.3"}
+      is_expected.to contain_exec('Create swap file /mnt/swap.3')
+        .with(
+          'command' => '/usr/bin/fallocate -l 4198M /mnt/swap.3',
+          'creates' => '/mnt/swap.3'
         )
     end
   end
@@ -125,11 +118,127 @@ describe 'swap_file::files' do
   context 'with cmd set to invalid value' do
     let(:params) do
       {
-        :cmd => 'invalid',
+        cmd: 'invalid'
       }
     end
     it 'should fail' do
       expect { should contain_class(subject) }.to raise_error(Puppet::Error, /Invalid cmd: invalid - \(Must be \'dd\' or \'fallocate\'\)/)
+    end
+  end
+
+  context 'resize_existing => true' do
+    context 'when swapfile_sizes fact exists and matches path' do
+      let(:params) do
+        {
+          swapfile: '/mnt/swap.resizeme',
+          resize_existing: true
+        }
+      end
+
+      let(:existing_swap_kb) { '204796' } # 200MB
+
+      let(:facts) do
+        {
+          operatingsystem: 'RedHat',
+          osfamily: 'RedHat',
+          operatingsystemrelease: '7',
+          concat_basedir: '/tmp',
+          memorysize: '1.00 GB',
+          swapfile_sizes: {
+            '/mnt/swap.resizeme' => existing_swap_kb,
+          }
+        }
+      end
+
+      it do
+        is_expected.to compile.with_all_deps
+      end
+      it do
+        should contain_swap_file__resize('/mnt/swap.resizeme').with('swapfile_path' => '/mnt/swap.resizeme',
+                                                                    'margin'                 => '50MB',
+                                                                    'expected_swapfile_size' => '1.00 GB',
+                                                                    'actual_swapfile_size'   => existing_swap_kb,
+                                                                    'before'                 => 'Exec[Create swap file /mnt/swap.resizeme]')
+      end
+      it do
+        is_expected.to contain_exec('Create swap file /mnt/swap.resizeme')
+          .with('command' => '/bin/dd if=/dev/zero of=/mnt/swap.resizeme bs=1M count=1024',
+                'creates' => '/mnt/swap.resizeme')
+      end
+      it do
+        is_expected.to contain_file('/mnt/swap.resizeme')
+          .with('owner' => 'root',
+                'group' => 'root',
+                'mode' => '0600',
+                'require' => 'Exec[Create swap file /mnt/swap.resizeme]')
+      end
+      it do
+        is_expected.to contain_exec('Attach swap file /mnt/swap.resizeme')
+          .with('command' => '/sbin/mkswap /mnt/swap.resizeme && /sbin/swapon /mnt/swap.resizeme',
+                'require' => 'File[/mnt/swap.resizeme]',
+                'unless' => '/sbin/swapon -s | grep /mnt/swap.resizeme')
+      end
+      it do
+        is_expected.to contain_mount('/mnt/swap.resizeme')
+          .with('require' => 'Exec[Attach swap file /mnt/swap.resizeme]')
+      end
+    end
+    context 'when swapfile_sizes fact does not exist' do
+      let(:params) do
+        {
+          swapfile: '/mnt/swap.nofact',
+          resize_existing: true
+        }
+      end
+      let(:facts) do
+        {
+          operatingsystem: 'RedHat',
+          osfamily: 'RedHat',
+          operatingsystemrelease: '7',
+          concat_basedir: '/tmp',
+          memorysize: '1.00 GB',
+          swapfile_sizes: nil,
+        }
+      end
+      it do
+        is_expected.to compile.with_all_deps
+      end
+      it do
+        should_not contain_swap_file__resize('/mnt/swap.nofact')
+      end
+    end
+    context 'when swapfile_sizes fact exits but file does not match' do
+      let(:params) do
+        {
+          swapfile: '/mnt/swap.factbutnomatch',
+          resize_existing: true
+        }
+      end
+      let(:facts) do
+        {
+          operatingsystem: 'RedHat',
+          osfamily: 'RedHat',
+          operatingsystemrelease: '7',
+          concat_basedir: '/tmp',
+          memorysize: '1.00 GB',
+          swapfile_sizes: {
+            '/mnt/swap.differentname' => '204796', # 200MB
+          }
+        }
+      end
+      it do
+        is_expected.to compile.with_all_deps
+      end
+      it do
+        is_expected.to contain_exec('Create swap file /mnt/swap.factbutnomatch')
+          .with(
+            'command' => '/bin/dd if=/dev/zero of=/mnt/swap.factbutnomatch bs=1M count=1024',
+            'creates' => '/mnt/swap.factbutnomatch'
+          )
+      end
+      it do
+        should_not contain_swap_file__resize('/mnt/swap.factbutnomatch')
+      end
     end
   end
 end

--- a/spec/defines/resize_spec.rb
+++ b/spec/defines/resize_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe 'swap_file::resize' do
+  let(:title) { 'default' }
+
+
+  let(:default_facts) do
+    {
+      :operatingsystem => 'RedHat',
+      :osfamily        => 'RedHat',
+      :operatingsystemrelease => '7',
+      :concat_basedir => '/tmp',
+      :memorysize => '1.00 GB',
+    }
+  end
+
+  # Add these two lines in a single test block to enable puppet and hiera debug mode
+  # Puppet::Util::Log.level = :debug
+  # Puppet::Util::Log.newdestination(:console)
+
+  context 'has resize execs if swapfile outside of margin range' do
+    let(:params) do
+      {
+        :swapfile_path          => '/mnt/swap.1',
+        :expected_swapfile_size => '1 GB',
+        :actual_swapfile_size   => '512 GB',
+      }
+    end
+
+    it do
+      is_expected.to compile.with_all_deps
+    end
+    it do
+      is_expected.to contain_exec('Detach swap file /mnt/swap.1 for resize').
+        with(
+          {
+            "command"=>"/sbin/swapoff /mnt/swap.1",
+            "onlyif"=>"/sbin/swapon -s | grep /mnt/swap.1"
+          }
+        )
+
+      is_expected.to contain_exec('Purge /mnt/swap.1 for resize').
+        with(
+          {
+            "command"=>"/bin/rm -f /mnt/swap.1",
+            "onlyif"=>"test -f /mnt/swap.1"
+          }
+        )
+    end
+  end
+
+  context 'wont have resize execs if swapfile inside of margin range' do
+    let(:params) do
+      {
+        :swapfile_path          => '/mnt/swap.1',
+        :expected_swapfile_size => '4 GB',
+        :actual_swapfile_size   => '3.9 GB',
+        :margin                 => '150MB',
+      }
+    end
+
+    it do
+      is_expected.to compile.with_all_deps
+    end
+    it do
+      is_expected.to_not contain_exec('Detach swap file /mnt/swap.1 for resize')
+    end
+    it do
+      is_expected.to_not contain_exec('Purge /mnt/swap.1 for resize')
+    end
+  end
+
+  context 'can get verboseness message' do
+    let(:params) do
+      {
+        :swapfile_path          => '/mnt/swap.1',
+        :expected_swapfile_size => '4 GB',
+        :actual_swapfile_size   => '5 GB',
+        :margin                 => '5MB',
+        :verbose                => true,
+      }
+    end
+
+    it do
+      is_expected.to compile.with_all_deps
+    end
+    it do
+      is_expected.to contain_exec('Detach swap file /mnt/swap.1 for resize')
+    end
+    it do
+      is_expected.to contain_exec('Purge /mnt/swap.1 for resize')
+    end
+    it do
+      is_expected.to contain_notify('Resizing Swapfile Alert /mnt/swap.1').with_name("Existing : 5368709120B\nExpected: 4294967296B\nMargin: 5242880B")
+    end
+  end
+
+end

--- a/spec/functions/difference_within_margin_spec.rb
+++ b/spec/functions/difference_within_margin_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'difference_within_margin' do
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params([]).and_raise_error(Puppet::ParseError, /Wrong number of arguments given \(1 for 2\)/i) }
+  it { is_expected.to run.with_params(['1','2']).and_raise_error(Puppet::ParseError, /Wrong number of arguments given \(1 for 2\)/i) }
+  it { is_expected.to run.with_params([],'2').and_raise_error(Puppet::ParseError, /arg\[0\] array cannot be empty/i) }
+
+  it { is_expected.to run.with_params([100,150],60).and_return(true) }
+  it { is_expected.to run.with_params([100,150],40).and_return(false) }
+  it { is_expected.to run.with_params([213909504, 209711104], 5242880).and_return(true) }
+  it { is_expected.to run.with_params([104853504,209715200],5242880).and_return(false) }
+
+  it { is_expected.to run.with_params(['100','150'],'60').and_return(true) }
+  it { is_expected.to run.with_params(['100','150'],'40').and_return(false) }
+  it { is_expected.to run.with_params(['213909504','209711104'],'5242880').and_return(true) }
+  it { is_expected.to run.with_params(['104853504','209715200'],'5242880').and_return(false) }
+
+
+end


### PR DESCRIPTION
* Inspired by the work by @acjohnson
* Uses the $::swapfile_sizes fact as a hash
* Checks if a swapfile already exists in the hash
* If it does, compares sizes
* If the size differs over the margin given (defaulting to 5MB) then it `swap off` the swap and deletes it
* Adding a `before` to the Exec means that it ensure's it'll get made before it.
* Adds some specific functions to allow cleaner code in the resize_swapfile defined type