### PR TITLE
Add a swapfile fact as a CSV

### DIFF
--- a/lib/facter/swapfile_sizes_csv.rb
+++ b/lib/facter/swapfile_sizes_csv.rb
@@ -1,0 +1,37 @@
+if File.exists?('/proc/swaps')
+  swap_file_array = []
+
+  swap_file_output = Facter::Util::Resolution.exec('cat /proc/swaps')
+
+    # Sample Output
+    # Filename                                Type    Size  Used  Priority
+    # /dev/dm-1                               partition 524284  0 -1
+    # /mnt/swap.1                             file    204796  0 -2
+    # /tmp/swapfile.fallocate                 file    204796  0 -3
+    swap_file_output_array = swap_file_output.split("\n")
+
+    # Remove the header line
+    swap_file_output_array.shift
+
+    swap_file_output_array.each do |line|
+
+      swap_file_line_array = line.gsub(/\s+/m, ' ').strip.split(" ")
+
+      # We only want swap-file information, not paritions
+      if swap_file_line_array[1] == 'file'
+        pipe_seperated_string = "#{swap_file_line_array[0]}||#{swap_file_line_array[2]}"
+        swap_file_array << pipe_seperated_string
+      end
+
+    end
+
+    swapfile_csv = swap_file_array.join(',')
+
+    Facter.add('swapfile_sizes_csv') do
+      confine :kernel => 'Linux'
+      setcode do
+        swapfile_csv
+      end
+    end
+
+end

--- a/spec/unit/facter/swapfiles_fact_csv_spec.rb
+++ b/spec/unit/facter/swapfiles_fact_csv_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe Facter::Util::Fact do
+  before {
+    Facter.clear
+  }
+
+  describe 'swapfile_sizes_csv' do
+    context 'returns swapfile_sizes when present' do
+      before do
+        Facter.fact(:kernel).stubs(:value).returns("Linux")
+        File.stubs(:exists?)
+        File.expects(:exists?).with('/proc/swaps').returns(true)
+        Facter::Util::Resolution.stubs(:exec)
+      end
+      it do
+        proc_swap_output = <<-EOS
+Filename        Type    Size  Used  Priority
+/dev/dm-1                               partition 524284  0 -1
+/mnt/swap.1                             file      204796  0 -2
+/tmp/swapfile.fallocate                 file      204796  0 -3
+        EOS
+        Facter::Util::Resolution.expects(:exec).with('cat /proc/swaps').returns(proc_swap_output)
+        expect(Facter.value(:swapfile_sizes_csv)).to eq('/mnt/swap.1||204796,/tmp/swapfile.fallocate||204796')
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
* This can be used to workaround the lack of hash facts when `stringify_facts` is true