### PR TITLE
Allows removing existing swap from a CSV fact

### DIFF
--- a/lib/puppet/parser/functions/swap_file_size_from_csv.rb
+++ b/lib/puppet/parser/functions/swap_file_size_from_csv.rb
@@ -1,0 +1,36 @@
+#
+# swap_file_size_from_csv.rb
+#
+module Puppet::Parser::Functions
+  newfunction(:swap_file_size_from_csv, :type => :rvalue, :doc => <<-EOS
+Given a csv of swap files and sizes, split by pipe (||), we can determine the size in bytes of the swapfile
+Will return false if the swapfile is not found in the csv
+*Examples:*
+    get_swap_file_size_from_csv('/mnt/swap.1','/mnt/swap.1||1019900,/mnt/swap.1||1019900')
+Would return: 1019900
+    get_swap_file_size_from_csv('/mnt/swap.2','/mnt/swap.1||1019900,/mnt/swap.1||1019900')
+Would return: false
+    EOS
+  ) do |arguments|
+    raise(Puppet::ParseError, "swap_file_size_from_csv(): Wrong number of arguments " +
+      "given (#{arguments.size} for 2)") if arguments.size < 2
+    unless arguments[0].is_a? String
+      raise(Puppet::ParseError, "swap_file_size_from_csv(): swapfile name but be a string (Got #{arguments[0].class}")
+    end
+    unless arguments[1].is_a? String
+      raise(Puppet::ParseError, "swap_file_size_from_csv(): Requires string to work with (Got #{arguments[1].class}")
+    end
+    lines = arguments[1].strip.split(',')
+
+    swapfile_found = false
+
+    lines.each do | swapfile_csv |
+      swapfile_csv_array = swapfile_csv.split(',')
+      swapfile_name = swapfile_csv.split('||')[0]
+      swapfile_size = swapfile_csv.split('||')[1]
+      swapfile_found = swapfile_size if arguments[0] == swapfile_name
+    end
+    swapfile_found
+  end
+end
+# vim: set ts=2 sw=2 et :

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -69,7 +69,17 @@ define swap_file::files (
         }
 
       } else {
-        fail('$resize_existing was set to true and stringify_facts was not false. This currently does not work, but will in the future. See https://github.com/petems/petems-swap_file/issues/57')
+        $existing_swapfile_size = swap_file_size_from_csv($swapfile,$::swapfile_sizes_csv)
+        if ($existing_swapfile_size) {
+          ::swap_file::resize { $swapfile:
+            swapfile_path          => $swapfile,
+            margin                 => $resize_margin,
+            expected_swapfile_size => $swapfilesize,
+            actual_swapfile_size   => $existing_swapfile_size,
+            verbose                => $resize_verbose,
+            before                 => Exec["Create swap file ${swapfile}"],
+          }
+        }
       }
     }
 

--- a/spec/acceptance/swap_file_resizing_stringify_true_spec.rb
+++ b/spec/acceptance/swap_file_resizing_stringify_true_spec.rb
@@ -32,15 +32,18 @@ describe 'swap_file class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfa
         pp = <<-EOS
         swap_file::files { 'default':
           ensure       => present,
-          swapfilesize => '100MB',
+          swapfilesize => '200MB',
           resize_existing => true,
         }
         EOS
 
         # Run it twice and test for idempotency
-        apply_manifest(pp, :expect_failures => true) do |r|
-          expect(r.stderr).to match(/stringify_facts was true/)
-        end
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true)
+      end
+      it 'should contain the given swapfile with the resized size (204796kb/200MB)' do
+        shell('/sbin/swapon -s | grep /mnt/swap.1', :acceptable_exit_codes => [0])
+        shell('/bin/cat /proc/swaps | grep 204796', :acceptable_exit_codes => [0])
       end
     end
   end

--- a/spec/functions/swap_file_size_from_csv_array_spec.rb
+++ b/spec/functions/swap_file_size_from_csv_array_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'swap_file_size_from_csv' do
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params([]).and_raise_error(Puppet::ParseError, /Wrong number of arguments given \(1 for 2\)/i) }
+  it { is_expected.to run.with_params(['1','2']).and_raise_error(Puppet::ParseError, /Wrong number of arguments given \(1 for 2\)/i) }
+  it { is_expected.to run.with_params([],'2').and_raise_error(Puppet::ParseError, /swapfile name but be a string/i) }
+
+  it { is_expected.to run.with_params('/mnt/swap.1','/mnt/swap.1||1019900,/mnt/swap.1||1019900').and_return('1019900') }
+  it { is_expected.to run.with_params('/mnt/swap.2','/mnt/swap.1||1019900,/mnt/swap.1||1019900').and_return(false) }
+
+end


### PR DESCRIPTION
* This allows us to work around on a system where stringify facts is true
* We instead make a CSV of swapfile paths and sizes, split by `||`
* We have a function to return if the swapfile exists in the CSV string, and if it does, what is the size of the existing swapfile in KB
* Updates acceptance test to actually test the new functionality