### PR TITLE
Make json file RFC 4627 valid

### DIFF
--- a/contributing.json
+++ b/contributing.json
@@ -17,7 +17,7 @@
     "subject_must_be_in_tense": "imperative",
     "subject_must_start_with_case": "upper",
     "subject_must_not_end_with_dot": true,
-    "body_cannot_be_empty": true,
+    "body_cannot_be_empty": true
   },
   "issue": {
     "subject_cannot_be_empty": true,


### PR DESCRIPTION
I noticed the json file has a trailing comma where it shouldn't, and this is hitting my linter.