### PR TITLE
Update to Augeas systcl module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,8 +3,9 @@ fixtures:
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
       ref: 4.7.0
-    sysctl:
-      repo: "git://github.com/fiddyspence/puppet-sysctl.git"
-      ref: 1.1.0
+    augeasproviders_sysctl:
+      repo: "git://github.com/hercules-team/augeasproviders_sysctl.git"
+    augeasproviders_core:
+      repo: "git://github.com/hercules-team/augeasproviders_core.git"
   symlinks:
     swap_file: "#{source_dir}"

--- a/manifests/swappiness.pp
+++ b/manifests/swappiness.pp
@@ -16,9 +16,8 @@ class swap_file::swappiness (
   validate_integer($swappiness, 100, 0)
 
   sysctl { 'vm.swappiness':
-    ensure    => 'present',
-    permanent => true,
-    value     => $swappiness,
+    ensure => 'present',
+    value  => $swappiness,
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -56,8 +56,12 @@
       "version_requirement": ">= 4.7.0"
     },
     {
-      "name": "fiddyspence/sysctl",
-      "version_requirement": "1.1.0"
+      "name": "herculesteam/augeasproviders_sysctl",
+      "version_requirement": ">=2.1.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_core",
+      "version_requirement": ">=2.1.0"
     }
   ]
 }

--- a/spec/classes/swappiness_spec.rb
+++ b/spec/classes/swappiness_spec.rb
@@ -9,7 +9,6 @@ describe 'swap_file::swappiness' do
   it do
     is_expected.to contain_sysctl('vm.swappiness').
              with({"ensure"=>"present",
-                   "permanent"=>"true",
                    "value"=>"65"})
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -26,7 +26,8 @@ RSpec.configure do |c|
     puppet_module_install(:source => proj_root, :module_name => 'swap_file')
     hosts.each do |host|
       shell('puppet module install puppetlabs-stdlib --version 4.7.0', { :acceptable_exit_codes => [0] })
-      shell('puppet module install fiddyspence-sysctl --version 1.1.0', { :acceptable_exit_codes => [0] })
+      shell('puppet module install herculesteam/augeasproviders_core --version 2.1.0', { :acceptable_exit_codes => [0] })
+      shell('puppet module install herculesteam/augeasproviders_sysctl --version 2.1.0', { :acceptable_exit_codes => [0] })
     end
   end
 end


### PR DESCRIPTION
This PR updates the module used to modify the `swappiness` value.

The previous module `fiddyspence/puppet-sysctl` has not been updated for ~2 years and it is not being tested with newer versions of Puppet.

In addition, the proposed module uses Augeas which has some advantages.