### PR TITLE
Fixes issue with empty fact

### DIFF
--- a/lib/facter/swapfile_sizes_csv.rb
+++ b/lib/facter/swapfile_sizes_csv.rb
@@ -25,7 +25,7 @@ if File.exists?('/proc/swaps')
 
     end
 
-    swapfile_csv = swap_file_array.join(',')
+    swapfile_csv = swap_file_array.join(',') unless swap_file_array.empty?
 
     Facter.add('swapfile_sizes_csv') do
       confine :kernel => 'Linux'

--- a/spec/unit/facter/swapfiles_fact_csv_spec.rb
+++ b/spec/unit/facter/swapfiles_fact_csv_spec.rb
@@ -25,5 +25,22 @@ Filename        Type    Size  Used  Priority
       end
     end
 
+    context 'returns nil when no swapfiles' do
+      before do
+        Facter.fact(:kernel).stubs(:value).returns("Linux")
+        File.stubs(:exists?)
+        File.expects(:exists?).with('/proc/swaps').returns(true)
+        Facter::Util::Resolution.stubs(:exec)
+      end
+      it do
+        proc_swap_output = <<-EOS
+Filename        Type    Size  Used  Priority
+/dev/dm-2                               partition 16612860  0 -1
+        EOS
+        Facter::Util::Resolution.expects(:exec).with('cat /proc/swaps').returns(proc_swap_output)
+        expect(Facter.value(:swapfile_sizes_csv)).to eq(nil)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
* When no facts on system, the value of `swap_file_array.join(',')` would be "", as the array is empty
* I had assumed an empty string was not valid for Facter, but I was wrong
* Add a guard, and add a spec for the fact change