### PR TITLE
validate_ functions converted to validate_legacy

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-      ref: 4.7.0
+      ref: 4.13.0
     augeasproviders_sysctl:
       repo: "git://github.com/hercules-team/augeasproviders_sysctl.git"
     augeasproviders_core:

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -45,10 +45,10 @@ define swap_file::files (
 )
 {
   # Parameter validation
-  validate_re($ensure, ['^absent$', '^present$'], "Invalid ensure: ${ensure} - (Must be 'present' or 'absent')")
-  validate_string($swapfile)
+  validate_legacy('Optional[String]', 'validate_re', $ensure, ['^absent$', '^present$'], "Invalid ensure: ${ensure} - (Must be 'present' or 'absent')")
+  validate_legacy('Optional[String]', 'validate_string', $swapfile)
   $swapfilesize_mb = to_bytes($swapfilesize) / 1048576
-  validate_bool($add_mount)
+  validate_legacy('Optional[Bool]', 'validate_bool', $add_mount)
 
   if $ensure == 'present' {
 

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -48,7 +48,7 @@ define swap_file::files (
   validate_legacy('Optional[String]', 'validate_re', $ensure, ['^absent$', '^present$'], "Invalid ensure: ${ensure} - (Must be 'present' or 'absent')")
   validate_legacy('Optional[String]', 'validate_string', $swapfile)
   $swapfilesize_mb = to_bytes($swapfilesize) / 1048576
-  validate_legacy('Optional[Bool]', 'validate_bool', $add_mount)
+  validate_legacy('Optional[Boolean]', 'validate_bool', $add_mount)
 
   if $ensure == 'present' {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class swap_file (
   } else {
     $files_hiera_merge_bool = str2bool($files_hiera_merge)
   }
-  validate_legacy('Optional[Bool]', 'validate_bool', $files_hiera_merge_bool)
+  validate_legacy('Optional[Boolean]', 'validate_bool', $files_hiera_merge_bool)
 
   # functionality
   if $files_hiera_merge_bool == true {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class swap_file (
   } else {
     $files_hiera_merge_bool = str2bool($files_hiera_merge)
   }
-  validate_bool($files_hiera_merge_bool)
+  validate_legacy('Optional[Bool]', 'validate_bool', $files_hiera_merge_bool)
 
   # functionality
   if $files_hiera_merge_bool == true {
@@ -59,7 +59,7 @@ class swap_file (
     $files_real = $files
   }
   if $files_real != undef {
-    validate_hash($files_real)
+    validate_legacy('Optional[Hash]', 'validate_hash', $files_real)
     create_resources('swap_file::files', $files_real)
   }
 }

--- a/manifests/swappiness.pp
+++ b/manifests/swappiness.pp
@@ -13,7 +13,7 @@ class swap_file::swappiness (
   $swappiness = 60,
 ) {
 
-  validate_integer($swappiness, 100, 0)
+  validate_legacy('Optional[Integer]', 'validate_integer', $swappiness, 100, 0)
 
   sysctl { 'vm.swappiness':
     ensure => 'present',

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.7.0 < 5.0.0"
+      "version_requirement": ">= 4.13.0"
     },
     {
       "name": "herculesteam/augeasproviders_sysctl",


### PR DESCRIPTION
This change is made to eliminate the deprecation warnings on the use of validate_ functions.