### PR TITLE
Replaces most validate_* with validate_legacy; Mostly fixes petems/petems-swap_file#80

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -46,9 +46,9 @@ define swap_file::files (
 {
   # Parameter validation
   validate_re($ensure, ['^absent$', '^present$'], "Invalid ensure: ${ensure} - (Must be 'present' or 'absent')")
-  validate_string($swapfile)
+  validate_legacy(String, 'validate_string', $swapfile)
   $swapfilesize_mb = to_bytes($swapfilesize) / 1048576
-  validate_bool($add_mount)
+  validate_legacy(Boolean, 'validate_bool', $add_mount)
 
   if $ensure == 'present' {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,12 +45,12 @@ class swap_file (
 ) {
 
   # variable handling
-  if is_bool($files_hiera_merge) == true {
+  if $files_hiera_merge =~ Boolean {
     $files_hiera_merge_bool = $files_hiera_merge
   } else {
     $files_hiera_merge_bool = str2bool($files_hiera_merge)
   }
-  validate_bool($files_hiera_merge_bool)
+  validate_legacy(Boolean, 'validate_bool', $files_hiera_merge_bool)
 
   # functionality
   if $files_hiera_merge_bool == true {
@@ -59,7 +59,7 @@ class swap_file (
     $files_real = $files
   }
   if $files_real != undef {
-    validate_hash($files_real)
+    validate_legacy(Hash, 'validate_hash', $files_real)
     create_resources('swap_file::files', $files_real)
   }
 }

--- a/manifests/swappiness.pp
+++ b/manifests/swappiness.pp
@@ -13,7 +13,7 @@ class swap_file::swappiness (
   $swappiness = 60,
 ) {
 
-  validate_integer($swappiness, 100, 0)
+  validate_legacy(Integer, 'validate_integer', $swappiness, [100, 0])
 
   sysctl { 'vm.swappiness':
     ensure => 'present',


### PR DESCRIPTION
Unfortunately this PR does not fix the `validate_re` at https://github.com/petems/petems-swap_file/pull/81/files#diff-fbeaa4299ed97aad958588c333db60d8L48